### PR TITLE
增加功能，修复问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,28 @@ Transform markdown to tiddlywiki5 wikitext syntax. Using unifiedjs.
 
 ## Basic features
 
-- `-` to `*`
-- `1.` to `#`
-- `#` to `!`
+- blockquote
+- bold
+- break
+- code
+- definition
+- emphasis
+- heading
+- html
+- image
+- image-reference
+- inline-code
+- italic
+- link
+- link-reference
+- list
+- list-item
+- paragraph
+- text
+- thematic-break
+- front-matter
+- table
+- footnote
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,84 @@ Transform markdown to tiddlywiki5 wikitext syntax. Using unifiedjs.
 - bold
 - break
 - code
-- definition
 - emphasis
 - heading
 - html
 - image
-- image-reference
 - inline-code
 - italic
 - link
-- link-reference
 - list
 - list-item
 - paragraph
 - text
 - thematic-break
-- front-matter
 - table
+
+### 定义和引用
+
+- link-reference
+- image-reference
+- definition
+
+```md
+[][label1]
+[alt1][label1]
+
+![][label2]
+![alt2][label2]
+
+[label1]: https://en.wikipedia.org/wiki/Hobbit#Lifestyle "Hobbit lifestyles"
+[label2]: https://example.com
+```
+
+```wikitext
+[ext[https://en.wikipedia.org/wiki/Hobbit#Lifestyle]]
+[ext[alt1|https://en.wikipedia.org/wiki/Hobbit#Lifestyle]]
+
+[img[https://example.com]]
+[img[alt2|https://example.com]]
+```
+
+[label1]: https://en.wikipedia.org/wiki/Hobbit#Lifestyle "Hobbit lifestyles"
+
+[label2]: https://example.com
+
+### 前置内容和脚注
+
+- front-matter
 - footnote
+
+```md
+---
+foo: bar
+---
+
+# Other markdown
+```
+
+````wikitext
+```yaml
+foo: bar
+```
+! Other markdown
+````
+
+```md
+In the Solar System, Mercury[^mercury] and Venus[^venus] have very small tilts.
+
+[^mercury]:
+**Mercury** is the first planet from the Sun and the smallest
+in the Solar System.
+
+[^venus]:
+**Venus** is the second planet from
+the Sun.
+```
+
+```wikitext
+In the Solar System, Mercury<<fnote "''Mercury'' is the first planet from the Sun and the smallest in the Solar System.">> and Venus<<fnote "''Venus'' is the second planet from the Sun.">> have very small tilts.
+```
 
 ## Usage
 
@@ -33,10 +93,11 @@ Website demo: https://tiddly-gittly.github.io/md-to-tid/
 
 ### Programmatic usage
 
-Get md data from your wiki and transform it:
+First, run `pnpm add md-to-tid` to install the md-to-tid package. Then, use the API of this package to transform the
+Markdown data obtained from your Wiki.
 
 ```ts
-import { md2tid } from 'md-to-tid';
+import {md2tid} from 'md-to-tid';
 
 const prevMDText = $tw.wiki.getTiddlerText(title);
 const tidText = md2tid(prevMDText);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "micromark-extension-gfm-footnote": "^2.1.0",
     "micromark-extension-gfm-table": "^2.1.1",
     "micromark-util-decode-string": "^2.0.1",
+    "unist-util-visit": "^5.0.0",
     "zwitch": "^2.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       micromark-util-decode-string:
         specifier: ^2.0.1
         version: 2.0.1
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       zwitch:
         specifier: ^2.0.4
         version: 2.0.4

--- a/src/mdast-util-to-wikitext/handle/blockquote.ts
+++ b/src/mdast-util-to-wikitext/handle/blockquote.ts
@@ -1,5 +1,5 @@
 import { Blockquote, Parents } from 'mdast';
-import { Info, Map, State } from '../types';
+import { Info, IndentLineMap, State } from '../types';
 
 export function blockquote(node: Blockquote, _: Parents | undefined, state: State, info: Info): string {
   const exit = state.enter('blockquote');
@@ -11,6 +11,6 @@ export function blockquote(node: Blockquote, _: Parents | undefined, state: Stat
   return value;
 }
 
-const map: Map = function map(line, _, blank) {
+const map: IndentLineMap = function map(line, _, blank) {
   return '>' + (blank ? '' : ' ') + line;
 };

--- a/src/mdast-util-to-wikitext/handle/image-reference.ts
+++ b/src/mdast-util-to-wikitext/handle/image-reference.ts
@@ -45,7 +45,7 @@ export function imageReference(node: ImageReference, _: Parents | undefined, sta
 
   if (type === 'full' || !alt || alt !== reference) {
     value += tracker.move(reference + ']]');
-  } else if (type === 'shortcut') {
+  } else if (type === 'shortcut' && alt !== '') {
     // Remove the unwanted `|`.
     value = value.slice(0, -1);
     value += tracker.move(']]');

--- a/src/mdast-util-to-wikitext/handle/image-reference.ts
+++ b/src/mdast-util-to-wikitext/handle/image-reference.ts
@@ -18,7 +18,11 @@ export function imageReference(node: ImageReference, _: Parents | undefined, sta
     after: ']',
     ...tracker.current(),
   });
-  value += tracker.move(alt + '|');
+
+  // 如果alt为空，则直接使用url
+  if (alt !== '') {
+    value += tracker.move(alt + '|');
+  }
 
   subexit();
   // Hide the fact that we’re in phrasing, because escapes don’t work.
@@ -30,7 +34,7 @@ export function imageReference(node: ImageReference, _: Parents | undefined, sta
   // Practically, in that case, there is no content, so it doesn’t matter that
   // we’ve tracked one too many characters.
 
-  const reference = state.safe(state.memo.get('definition')?.get(state.associationId(node)), {
+  const reference = state.safe(state.memo.get('definition')?.get(state.associationId(node)) || state.associationId(node), {
     before: value,
     after: ']]',
     ...tracker.current(),
@@ -44,6 +48,7 @@ export function imageReference(node: ImageReference, _: Parents | undefined, sta
   } else if (type === 'shortcut') {
     // Remove the unwanted `|`.
     value = value.slice(0, -1);
+    value += tracker.move(']]');
   } else {
     value += tracker.move(']]');
   }

--- a/src/mdast-util-to-wikitext/handle/image-reference.ts
+++ b/src/mdast-util-to-wikitext/handle/image-reference.ts
@@ -4,20 +4,21 @@ import { Info, State } from '../types';
 imageReference.peek = imageReferencePeek;
 
 // ImageReference: 链接引用变量的节点，结合 Definition 使用，不过只是图片引用变量的节点
-// ![][]
-// TODO 暂时不处理
+// ![alt][label]
+// [label]: url "title"
+// [img[An explanatory tooltip|Motovun Jack.jpg]]
 export function imageReference(node: ImageReference, _: Parents | undefined, state: State, info: Info): string {
   const type = node.referenceType;
   const exit = state.enter('imageReference');
   let subexit = state.enter('label');
   const tracker = state.createTracker(info);
-  let value = tracker.move('![');
+  let value = tracker.move('[img[');
   const alt = state.safe(node.alt, {
     before: value,
     after: ']',
     ...tracker.current(),
   });
-  value += tracker.move(alt + '][');
+  value += tracker.move(alt + '|');
 
   subexit();
   // Hide the fact that we’re in phrasing, because escapes don’t work.
@@ -28,9 +29,10 @@ export function imageReference(node: ImageReference, _: Parents | undefined, sta
   // up making a `shortcut` reference, because then there is no brace output.
   // Practically, in that case, there is no content, so it doesn’t matter that
   // we’ve tracked one too many characters.
-  const reference = state.safe(state.associationId(node), {
+
+  const reference = state.safe(state.memo.get('definition')?.get(state.associationId(node)), {
     before: value,
-    after: ']',
+    after: ']]',
     ...tracker.current(),
   });
   subexit();
@@ -38,17 +40,17 @@ export function imageReference(node: ImageReference, _: Parents | undefined, sta
   exit();
 
   if (type === 'full' || !alt || alt !== reference) {
-    value += tracker.move(reference + ']');
+    value += tracker.move(reference + ']]');
   } else if (type === 'shortcut') {
-    // Remove the unwanted `[`.
+    // Remove the unwanted `|`.
     value = value.slice(0, -1);
   } else {
-    value += tracker.move(']');
+    value += tracker.move(']]');
   }
 
   return value;
 }
 
 function imageReferencePeek(): string {
-  return '!';
+  return '[img[';
 }

--- a/src/mdast-util-to-wikitext/handle/link-embed.ts
+++ b/src/mdast-util-to-wikitext/handle/link-embed.ts
@@ -23,7 +23,7 @@ export function linkEmbed(node: Text, state: State, info: Info) {
       // [[Link|AltText|AltText1|...]]
       const verticalBarIndex = match.indexOf('|');
       let linkText = match.substring(0, verticalBarIndex);
-      const altText = match.substring(verticalBarIndex + 1);
+      const altText = match.substring(verticalBarIndex + 1).replaceAll("|","_");
       if (verticalBarIndex === -1) {
         transformerRegexpInternalLink.push(item);
       } else {

--- a/src/mdast-util-to-wikitext/handle/link-embed.ts
+++ b/src/mdast-util-to-wikitext/handle/link-embed.ts
@@ -1,0 +1,66 @@
+import { Text } from 'mdast';
+import { Info, State } from '../types';
+
+export function linkEmbed(node: Text, state: State, info: Info) {
+  // 从node.value 找到所有符合要求的语法，存储下来。
+  // 存储的结果然后safe一下，
+  // 存储的结果转换语法
+  // 然后node.value整体safe的结果字符串替换全局替换为转换的语法。
+  const patternInternalLink = /(?<!!)\[\[(.*?)]]/g;
+  const patternEmbed = /!\[\[(.*?)]]/g;
+  const regexpInternalLink = node.value.match(patternInternalLink) || [];
+  const regexpEmbed = node.value.match(patternEmbed) || [];
+  let safeRegexpInternalLink = [];
+  let safeRegexpEmbed = [];
+  let transformerRegexpInternalLink = [];
+  let transformerRegexpEmbed = [];
+  for (const item of regexpInternalLink) {
+    safeRegexpInternalLink.push(state.safe(item, info));
+    patternInternalLink.lastIndex = 0;
+    const execArray = patternInternalLink.exec(item);
+    const match = execArray && execArray[1];
+    if (match) {
+      // [[Link|AltText|AltText1|...]]
+      const verticalBarIndex = match.indexOf('|');
+      let linkText = match.substring(0, verticalBarIndex);
+      const altText = match.substring(verticalBarIndex + 1);
+      if (verticalBarIndex === -1) {
+        transformerRegexpInternalLink.push(item);
+      } else {
+        // [[Displayed Link Title|Tiddler Title]]
+        transformerRegexpInternalLink.push(`[[${altText}|${linkText}]]`);
+      }
+    } else {
+      transformerRegexpInternalLink.push(item);
+    }
+  }
+  for (const item of regexpEmbed) {
+    safeRegexpEmbed.push(state.safe(item, info));
+    patternEmbed.lastIndex = 0;
+    const execArray = patternEmbed.exec(item);
+    const match = execArray && execArray[1];
+    if (match) {
+      // ![[Embeds|AltText|AltText1|...|200x400]]
+      // 黑曜石嵌入笔记和图像共用一个语法，但太微是分开的不同的语法。
+      // 选择最简单的共同点{{条目名}}
+      const firstVerticalBarIndex = match.indexOf('|');
+      if (firstVerticalBarIndex === -1) {
+        transformerRegexpEmbed.push(`{{${match}}}`);
+      } else {
+        transformerRegexpEmbed.push(`{{${match.substring(0, firstVerticalBarIndex)}}}`);
+      }
+    } else {
+      transformerRegexpEmbed.push(item);
+    }
+  }
+  let safeArray = safeRegexpInternalLink.concat(safeRegexpEmbed);
+  let transformerArray = transformerRegexpInternalLink.concat(transformerRegexpEmbed);
+  let allArrayLength = regexpEmbed.length + regexpInternalLink.length;
+  let index = -1;
+  let result = state.safe(node.value, info);
+  while (index++ < allArrayLength) {
+    result = result.replaceAll(safeArray[index], transformerArray[index]);
+  }
+
+  return result;
+}

--- a/src/mdast-util-to-wikitext/handle/list-item.ts
+++ b/src/mdast-util-to-wikitext/handle/list-item.ts
@@ -1,6 +1,6 @@
 import { checkBullet } from '../util/check-bullet';
 import { ListItem, Parents } from 'mdast';
-import { Info, Map, State } from '../types';
+import { Info, IndentLineMap, State } from '../types';
 import { checkBulletOrdered } from '../util/check-bullet-ordered';
 
 export function listItem(node: ListItem, parent: Parents | undefined, state: State, info: Info): string {
@@ -26,7 +26,7 @@ export function listItem(node: ListItem, parent: Parents | undefined, state: Sta
   tracker.move(bullet.repeat(size - bullet.length));
   tracker.shift(size);
   const exit = state.enter('listItem');
-  const map: Map = function map(line, index, blank) {
+  const map: IndentLineMap = function map(line, index, blank) {
     if (index) {
       if (line.startsWith("#") || line.startsWith("*")) {
         let old_bullet = line.split(" ")[0]

--- a/src/mdast-util-to-wikitext/handle/text.ts
+++ b/src/mdast-util-to-wikitext/handle/text.ts
@@ -1,6 +1,7 @@
 import { Parents, Text } from 'mdast';
 import { Info, State } from '../types';
+import { linkEmbed } from './link-embed';
 
 export function text(node: Text, _: Parents | undefined, state: State, info: Info): string {
-  return state.safe(node.value, info);
+  return linkEmbed(node,state,info);
 }

--- a/src/mdast-util-to-wikitext/index.ts
+++ b/src/mdast-util-to-wikitext/index.ts
@@ -58,9 +58,10 @@ export function toTid(tree: Nodes, options: Options | null | undefined): string 
     safe: safeBound,
     stack: [],
     unsafe: [...unsafe],
-    useMemo: new Map(),
+    memo: new Map(),
   };
 
+  // 初始配置
   configure(state, settings);
 
   // 注册表格处理函数
@@ -91,7 +92,9 @@ export function toTid(tree: Nodes, options: Options | null | undefined): string 
     handlers: state.handlers,
   });
 
+  // 预先记忆定义用于后面脚注、链接、图片的引用
   const footnoteDefinitionDict: Map<string, string> = new Map();
+  const definitionDict: Map<string, string> = new Map();
   visit(tree, 'footnoteDefinition', function (node, index, parent) {
     let fd_text = state
       .containerFlow(node, {
@@ -100,7 +103,11 @@ export function toTid(tree: Nodes, options: Options | null | undefined): string 
       })
       .replaceAll('\n', ' ');
     footnoteDefinitionDict.set(association(node), fd_text);
-    state.useMemo.set('footnoteDefinition', footnoteDefinitionDict);
+    state.memo.set('footnoteDefinition', footnoteDefinitionDict);
+  });
+  visit(tree, 'definition', function (node, index, parent) {
+    definitionDict.set(association(node), node.url);
+    state.memo.set('definition', definitionDict);
   });
 
   let result = state.handle(tree, undefined, state, {

--- a/src/mdast-util-to-wikitext/types.ts
+++ b/src/mdast-util-to-wikitext/types.ts
@@ -814,7 +814,7 @@ export interface State {
   /**
    * 记忆全局变量
    */
-  useMemo: Map<string, Map<string, string>>;
+  memo: Map<string, Map<string, string>>;
 }
 
 /**

--- a/src/mdast-util-to-wikitext/types.ts
+++ b/src/mdast-util-to-wikitext/types.ts
@@ -495,7 +495,7 @@ export type Handle = (
  * @returns
  *   Padded value.
  */
-export type IndentLines = (value: string, map: Map) => string;
+export type IndentLines = (value: string, map: IndentLineMap) => string;
 
 /**
  * Info on the surrounding of the node that is serialized.
@@ -554,13 +554,12 @@ export type Join = (left: FlowChildren, right: FlowChildren, parent: FlowParents
  * @returns
  *   Padded line.
  */
-export type Map = (value: string, line: number, blank: boolean) => string;
+export type IndentLineMap = (value: string, line: number, blank: boolean) => string;
 
 /**
  * Configuration (optional).
  */
 export interface Options {
-  firstLineBlank?: boolean | null | undefined;
   /**
    * Whether to align the delimiters (default: `true`).
    */
@@ -812,6 +811,10 @@ export interface State {
    * Applied unsafe patterns.
    */
   unsafe: Array<Unsafe>;
+  /**
+   * 记忆全局变量
+   */
+  useMemo: Map<string, Map<string, string>>;
 }
 
 /**

--- a/src/mdast-util-to-wikitext/util/frontmatter.ts
+++ b/src/mdast-util-to-wikitext/util/frontmatter.ts
@@ -23,7 +23,7 @@ export function frontMatterToTid(options: Options) {
     // Typing this is the responsibility of the end user.
     handlers[matter.type] = handler(matter);
 
-    const open = fence(matter, 'open');
+    const open = fence(matter, 'open') + matter.type;
 
     gfmUnsafe.push({
       atBreak: true,
@@ -44,7 +44,7 @@ export function frontMatterToTid(options: Options) {
  *   Handler.
  */
 function handler(matter: Matter): (node: Literal) => string {
-  const open = fence(matter, 'open');
+  const open = fence(matter, 'open') + matter.type;
   const close = fence(matter, 'close');
 
   return handle;
@@ -91,5 +91,5 @@ function fence(matter: Matter, prop: 'close' | 'open'): string {
  *   Thing to use for the opening or closing.
  */
 function pick(schema: Info | string, prop: 'close' | 'open'): string {
-  return typeof schema === 'string' ? schema : schema[prop];
+  return typeof schema === 'string' ? '`' : schema[prop];
 }

--- a/src/mdast-util-to-wikitext/util/frontmatter.ts
+++ b/src/mdast-util-to-wikitext/util/frontmatter.ts
@@ -1,7 +1,7 @@
-import { Info, Matter, Options, toMatters } from 'micromark-extension-frontmatter';
+import {Matter, Options, toMatters} from 'micromark-extension-frontmatter';
 import escapeStringRegexp from 'escape-string-regexp';
-import { Literal } from 'mdast';
-import { Options as ToMarkdownExtension } from '../types';
+import {Literal} from 'mdast';
+import {Options as ToMarkdownExtension} from '../types';
 
 /**
  * Create an extension for `mdast-util-to-markdown`.
@@ -23,7 +23,7 @@ export function frontMatterToTid(options: Options) {
     // Typing this is the responsibility of the end user.
     handlers[matter.type] = handler(matter);
 
-    const open = fence(matter, 'open') + matter.type;
+    const open = '`'.repeat(3) + matter.type;
 
     gfmUnsafe.push({
       atBreak: true,
@@ -44,8 +44,8 @@ export function frontMatterToTid(options: Options) {
  *   Handler.
  */
 function handler(matter: Matter): (node: Literal) => string {
-  const open = fence(matter, 'open') + matter.type;
-  const close = fence(matter, 'close');
+  const open = '`'.repeat(3) + matter.type;
+  const close = '`'.repeat(3);
 
   return handle;
 
@@ -60,36 +60,4 @@ function handler(matter: Matter): (node: Literal) => string {
   function handle(node: Literal): string {
     return open + (node.value ? '\n' + node.value : '') + '\n' + close;
   }
-}
-
-/**
- * Get an `open` or `close` fence.
- *
- * @param {Matter} matter
- *   Structure.
- * @param {'close' | 'open'} prop
- *   Field to get.
- * @returns {string}
- *   Fence.
- */
-function fence(matter: Matter, prop: 'close' | 'open'): string {
-  return matter.marker
-    ? pick(matter.marker, prop).repeat(3)
-    : // @ts-expect-error: They’re mutually exclusive.
-      pick(matter.fence, prop);
-}
-
-/**
- * Take `open` or `close` fields when schema is an info object, or use the
- * given value when it is a string.
- *
- * @param {Info | string} schema
- *   Info object or value.
- * @param {'close' | 'open'} prop
- *   Field to get.
- * @returns {string}
- *   Thing to use for the opening or closing.
- */
-function pick(schema: Info | string, prop: 'close' | 'open'): string {
-  return typeof schema === 'string' ? '`' : schema[prop];
 }

--- a/src/mdast-util-to-wikitext/util/gfm-footnote.ts
+++ b/src/mdast-util-to-wikitext/util/gfm-footnote.ts
@@ -29,7 +29,7 @@ export function gfmFootnoteToTid(options: Options) {
 }
 
 function footnoteReferencePeek() {
-  return '[';
+  return '<<fnote "';
 }
 
 function footnoteReference(node: FootnoteReference, _: Parents | undefined, state: State, info: Info) {

--- a/src/mdast-util-to-wikitext/util/gfm-footnote.ts
+++ b/src/mdast-util-to-wikitext/util/gfm-footnote.ts
@@ -37,8 +37,7 @@ function footnoteReference(node: FootnoteReference, _: Parents | undefined, stat
   let value = tracker.move('<<fnote "');
   const exit = state.enter('footnoteReference');
   const subexit = state.enter('reference');
-  let footnote = state.useMemo.get('footnoteDefinition')?.get(state.associationId(node));
-  value += tracker.move(footnote);
+  value += tracker.move(state.useMemo.get('footnoteDefinition')?.get(state.associationId(node)));
   subexit();
   exit();
   value += tracker.move('">>');

--- a/src/mdast-util-to-wikitext/util/gfm-footnote.ts
+++ b/src/mdast-util-to-wikitext/util/gfm-footnote.ts
@@ -3,22 +3,6 @@ import { Info, Options, State, Unsafe } from '../types';
 
 footnoteReference.peek = footnoteReferencePeek;
 
-function footnoteReferencePeek() {
-  return '[';
-}
-
-function footnoteReference(node: FootnoteReference, _: Parents | undefined, state: State, info: Info) {
-  const tracker = state.createTracker(info);
-  let value = tracker.move('[^');
-  const exit = state.enter('footnoteReference');
-  const subexit = state.enter('reference');
-  value += tracker.move(state.safe(state.associationId(node), { after: ']', before: value }));
-  subexit();
-  exit();
-  value += tracker.move(']');
-  return value;
-}
-
 /**
  * GFM表格注册脚注
  *
@@ -28,12 +12,6 @@ function footnoteReference(node: FootnoteReference, _: Parents | undefined, stat
  *   Extension for `mdast-util-to-tid`.
  */
 export function gfmFootnoteToTid(options: Options) {
-  // To do: next major: change default.
-  let firstLineBlank = false;
-
-  if (options && options.firstLineBlank) {
-    firstLineBlank = true;
-  }
   const gfmUnsafe: Array<Unsafe> = [{ character: '[', inConstruct: ['label', 'phrasing', 'reference'] }];
   return {
     // This is on by default already.
@@ -42,33 +20,27 @@ export function gfmFootnoteToTid(options: Options) {
   };
 
   function footnoteDefinition(node: FootnoteDefinition, _: Parents | undefined, state: State, info: Info) {
-    const tracker = state.createTracker(info);
-    let value = tracker.move('[^');
     const exit = state.enter('footnoteDefinition');
     const subexit = state.enter('label');
-    value += tracker.move(state.safe(state.associationId(node), { before: value, after: ']' }));
     subexit();
-
-    value += tracker.move(']:');
-
-    if (node.children && node.children.length > 0) {
-      tracker.shift(4);
-
-      value += tracker.move(
-        (firstLineBlank ? '\n' : ' ') + state.indentLines(state.containerFlow(node, tracker.current()), firstLineBlank ? mapAll : mapExceptFirst),
-      );
-    }
-
     exit();
-
-    return value;
+    return '';
   }
 }
 
-function mapExceptFirst(value: string, line: number, blank: boolean) {
-  return line === 0 ? value : mapAll(value, line, blank);
+function footnoteReferencePeek() {
+  return '[';
 }
 
-function mapAll(value: string | number, line: number, blank: boolean) {
-  return (blank ? '' : '    ') + value;
+function footnoteReference(node: FootnoteReference, _: Parents | undefined, state: State, info: Info) {
+  const tracker = state.createTracker(info);
+  let value = tracker.move('<<fnote "');
+  const exit = state.enter('footnoteReference');
+  const subexit = state.enter('reference');
+  let footnote = state.useMemo.get('footnoteDefinition')?.get(state.associationId(node));
+  value += tracker.move(footnote);
+  subexit();
+  exit();
+  value += tracker.move('">>');
+  return value;
 }

--- a/src/mdast-util-to-wikitext/util/gfm-footnote.ts
+++ b/src/mdast-util-to-wikitext/util/gfm-footnote.ts
@@ -37,7 +37,7 @@ function footnoteReference(node: FootnoteReference, _: Parents | undefined, stat
   let value = tracker.move('<<fnote "');
   const exit = state.enter('footnoteReference');
   const subexit = state.enter('reference');
-  value += tracker.move(state.useMemo.get('footnoteDefinition')?.get(state.associationId(node)));
+  value += tracker.move(state.memo.get('footnoteDefinition')?.get(state.associationId(node)));
   subexit();
   exit();
   value += tracker.move('">>');

--- a/src/mdast-util-to-wikitext/util/indent-lines.ts
+++ b/src/mdast-util-to-wikitext/util/indent-lines.ts
@@ -1,4 +1,4 @@
-import { Map } from '../types';
+import { IndentLineMap } from '../types';
 
 /**
  * 正则表达式，用于匹配换行符（支持不同操作系统的换行符格式）
@@ -9,10 +9,10 @@ const eol = /\r?\n|\r/g;
  * 对输入的字符串按行进行处理，并根据提供的映射函数进行转换。
  *
  * @param {string} value - 要处理的原始字符串。
- * @param {Map} map - 用于处理每一行的映射函数。
+ * @param {IndentLineMap} map - 用于处理每一行的映射函数。
  * @returns {string} - 处理后的字符串。
  */
-export function indentLines(value: string, map: Map): string {
+export function indentLines(value: string, map: IndentLineMap): string {
   // 用于存储处理后的每一行和换行符
   const result: string[] = [];
   // 记录当前处理的起始位置

--- a/test/escape.test.mjs
+++ b/test/escape.test.mjs
@@ -179,7 +179,7 @@ describe('escape', () => {
         type: 'paragraph',
         children: [{ type: 'text', value: '[[a.jpg]]' }],
       }),
-    ).toEqual('\\[\\[a.jpg]]\n');
+    ).toEqual('[[a.jpg]]\n');
   });
 
   test('should not escape what would otherwise not be a link (resource)', () => {

--- a/test/escape.test.mjs
+++ b/test/escape.test.mjs
@@ -144,7 +144,7 @@ describe('escape', () => {
           },
         ],
       }),
-    ).toEqual('\\![a][b]\n');
+    ).toEqual('\\![ext[a|b]]\n');
   });
 
   test('should escape what would otherwise be an image (reference)', () => {

--- a/test/gfm.test1.ts
+++ b/test/gfm.test1.ts
@@ -56,9 +56,11 @@ let reference = `
 let obsidian_internal_link_and_embeds = `
 [[Link]]
 [[Link|AltText]]
+[[Link|AltText|AltText1|...]]
 
 ![[Embeds]]
 ![[Embeds|AltText]]
+![[Embeds|AltText|AltText1|...|200x400]]
 `;
 
 console.log(md2tid(obsidian_internal_link_and_embeds));

--- a/test/gfm.test1.ts
+++ b/test/gfm.test1.ts
@@ -1,5 +1,4 @@
 import { md2tid } from '../src';
-import { linkReference } from '../src/mdast-util-to-wikitext/handle/link-reference';
 
 let tab = `
 # 这是一个表格
@@ -40,10 +39,18 @@ foo: bar
 `;
 
 let reference = `
+[][]
+![][]
+[alt1][]
+![alt2][]
+
+[][label1]
+![][label2]
 [alt1][label1]
 ![alt2][label2]
 
 [label1]: https://en.wikipedia.org/wiki/Hobbit#Lifestyle "Hobbit lifestyles"
 [label2]: https://example.com
-`
+`;
+
 console.log(md2tid(reference));

--- a/test/gfm.test1.ts
+++ b/test/gfm.test1.ts
@@ -63,4 +63,9 @@ let obsidian_internal_link_and_embeds = `
 ![[Embeds|AltText|AltText1|...|200x400]]
 `;
 
+// 用不到的其它语法
+// ![[内部链接#^b15695]]
+// ![[Document.pdf#page=3]]
+// ![[Document.pdf#height=400]]
+
 console.log(md2tid(obsidian_internal_link_and_embeds));

--- a/test/gfm.test1.ts
+++ b/test/gfm.test1.ts
@@ -53,4 +53,12 @@ let reference = `
 [label2]: https://example.com
 `;
 
-console.log(md2tid(reference));
+let obsidian_internal_link_and_embeds = `
+[[Link]]
+[[Link|AltText]]
+
+![[Embeds]]
+![[Embeds|AltText]]
+`;
+
+console.log(md2tid(obsidian_internal_link_and_embeds));

--- a/test/gfm.test1.ts
+++ b/test/gfm.test1.ts
@@ -1,4 +1,5 @@
 import { md2tid } from '../src';
+import { linkReference } from '../src/mdast-util-to-wikitext/handle/link-reference';
 
 let tab = `
 # 这是一个表格
@@ -38,4 +39,11 @@ foo: bar
 # Other markdown
 `;
 
-console.log(md2tid(footnote));
+let reference = `
+[alt1][label1]
+![alt2][label2]
+
+[label1]: https://en.wikipedia.org/wiki/Hobbit#Lifestyle "Hobbit lifestyles"
+[label2]: https://example.com
+`
+console.log(md2tid(reference));

--- a/test/gfm.test1.ts
+++ b/test/gfm.test1.ts
@@ -38,4 +38,4 @@ foo: bar
 # Other markdown
 `;
 
-console.log(md2tid(tomlFrontMatter));
+console.log(md2tid(footnote));

--- a/test/link.test.mjs
+++ b/test/link.test.mjs
@@ -174,19 +174,19 @@ describe('link', () => {
 
 describe('linkReference', (t) => {
   test('should support a link reference (nonsensical)', () => {
-    expect(toString({ type: 'linkReference' })).toEqual('[][]\n');
+    expect(toString({ type: 'linkReference' })).toEqual('[ext[]]\n');
   });
 
   test('should support `children`', () => {
-    expect(toString({ type: 'linkReference', children: [{ type: 'text', value: 'a' }] })).toEqual('[a][]\n');
+    expect(toString({ type: 'linkReference', children: [{ type: 'text', value: 'a' }] })).toEqual('[ext[a|]]\n');
   });
 
   test('should support an `identifier` (nonsensical)', () => {
-    expect(toString({ type: 'linkReference', identifier: 'a' })).toEqual('[][a]\n');
+    expect(toString({ type: 'linkReference', identifier: 'a' })).toEqual('[ext[a]]\n');
   });
 
   test('should support a `label` (nonsensical)', () => {
-    expect(toString({ type: 'linkReference', label: 'a' })).toEqual('[][a]\n');
+    expect(toString({ type: 'linkReference', label: 'a' })).toEqual('[ext[a]]\n');
   });
 
   test('should support `referenceType: "shortcut"`', () => {
@@ -197,7 +197,7 @@ describe('linkReference', (t) => {
         label: 'A',
         referenceType: 'shortcut',
       }),
-    ).toEqual('[A]\n');
+    ).toEqual('[ext[A]]\n');
   });
 
   test('should support `referenceType: "collapsed"`', () => {
@@ -209,7 +209,7 @@ describe('linkReference', (t) => {
         identifier: 'a',
         referenceType: 'collapsed',
       }),
-    ).toEqual('[A][]\n');
+    ).toEqual('[ext[A|]]\n');
   });
 
   test('should support `referenceType: "full"` (default)', () => {
@@ -221,7 +221,7 @@ describe('linkReference', (t) => {
         identifier: 'a',
         referenceType: 'full',
       }),
-    ).toEqual('[A][A]\n');
+    ).toEqual('[ext[A|A]]\n');
   });
 
   test('should prefer label over identifier', () => {
@@ -233,7 +233,7 @@ describe('linkReference', (t) => {
         identifier: '&amp;',
         referenceType: 'full',
       }),
-    ).toEqual('[&][&]\n');
+    ).toEqual('[ext[&|&]]\n');
   });
 
   test('should decode `identifier` if w/o `label`', () => {
@@ -244,7 +244,7 @@ describe('linkReference', (t) => {
         identifier: '&amp;',
         referenceType: 'full',
       }),
-    ).toEqual('[&][&]\n');
+    ).toEqual('[ext[&|&]]\n');
   });
 
   test('should support incorrect character references', () => {
@@ -260,7 +260,7 @@ describe('linkReference', (t) => {
           },
         ],
       }),
-    ).toEqual('[\\&a;][&b;]\n');
+    ).toEqual('[ext[\\&a;|&b;]]\n');
   });
 
   test('should unescape `identifier` if w/o `label`', () => {
@@ -271,7 +271,7 @@ describe('linkReference', (t) => {
         identifier: '\\+',
         referenceType: 'full',
       }),
-    ).toEqual('[+][+]\n');
+    ).toEqual('[ext[+|+]]\n');
   });
 
   test('should use a collapsed reference if w/o `referenceType` and the label matches the reference', () => {
@@ -282,7 +282,7 @@ describe('linkReference', (t) => {
         label: 'a',
         identifier: 'a',
       }),
-    ).toEqual('[a][]\n');
+    ).toEqual('[ext[a|]]\n');
   });
 
   test('should use a full reference if w/o `referenceType` and the label does not match the reference', () => {
@@ -293,7 +293,7 @@ describe('linkReference', (t) => {
         label: 'b',
         identifier: 'b',
       }),
-    ).toEqual('[a][b]\n');
+    ).toEqual('[ext[a|b]]\n');
   });
 
   test.skip('should use a full reference if w/o `referenceType` and the label does not match the reference', () => {
@@ -316,6 +316,6 @@ describe('linkReference', (t) => {
         referenceType: 'full',
         children: [],
       }),
-    ).toEqual('[][a!\\[b\\](c*d_e\\[f_g`h<i</j]\n');
+    ).toEqual('[ext[a!\\[b\\](c*d_e\\[f_g`h<i</j]]\n');
   });
 });

--- a/test/quote.test.mjs
+++ b/test/quote.test.mjs
@@ -255,7 +255,7 @@ describe('blockquote', () => {
           },
         ],
       }),
-    ).toEqual('> a\n> ![b\n> c][d\n> e]\n> g\n');
+    ).toEqual('> a\n> [img[b\n> c|d\n> e]]\n> g\n');
   });
 
   test('should support a link (resource) in a block quote', () => {
@@ -302,7 +302,7 @@ describe('blockquote', () => {
           },
         ],
       }),
-    ).toEqual('> a\n> [b\n> c][d\n> e]\n> g\n');
+    ).toEqual('> a\n> [ext[b\n> c|d\n> e]]\n> g\n');
   });
 
   test('should support a list in a block quote', () => {


### PR DESCRIPTION
- 先定义后引用的链接、引用的图片现在可以正常使用了。
- 脚注使用TW-Refnotes插件提供的<<fnote "note">>宏
- frontmatter用前置code+language标注。
- 支持黑曜石内部链接和嵌入（嵌入仅支持笔记或图片名称，不支持altText、size）
- 更新了自述